### PR TITLE
Add opt-in response cost metadata support to Desearch Python SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,37 @@ async def main() -> None:
 asyncio.run(main())
 ```
 
+
+### Read optional response cost metadata
+
+Default calls continue to return the original typed payload only:
+
+```python
+result = await client.ai_search(
+    prompt="What happened in Bittensor this week?",
+    tools=["web", "twitter"],
+)
+print(result.text)
+```
+
+When you want per-request cost visibility, opt in with `include_metadata=True`:
+
+```python
+response = await client.ai_search(
+    prompt="What happened in Bittensor this week?",
+    tools=["web", "twitter"],
+    include_metadata=True,
+)
+
+print(response.data.text)
+print(response.metadata.cost_cents)
+print(response.metadata.usage_count)
+print(response.metadata.service)
+print(response.metadata.currency)
+```
+
+The SDK reads metadata from the same API response headers (`X-Desearch-Cost-Cents`, `X-Desearch-Usage-Count`, `X-Desearch-Service`, and `X-Desearch-Currency`). Missing or malformed numeric headers are exposed as `None` instead of breaking a successful API call.
+
 ### Reuse the client manually
 
 ```python
@@ -84,9 +115,10 @@ Dependencies declared in source:
 | Install local repo with Poetry | `poetry install` | Uses `pyproject.toml` |
 | Build distributables | `poetry build` | Produces package artifacts |
 | Publish package | `./publish.sh` | Repository script |
+| Run tests | `poetry run python -m unittest discover -s tests -v` | Uses the stdlib unittest runner |
 | Build Sphinx docs | `make -C docs html` | Requires Sphinx dev deps |
 
-There are currently **no dedicated test, lint, or format commands configured in the repo**. This is an accurate reflection of the current source tree, not an omission in this README.
+A minimal unittest suite covers response metadata behavior. There is still no dedicated lint or format command configured in the repo.
 
 ## Tech stack
 
@@ -123,7 +155,7 @@ There are currently **no dedicated test, lint, or format commands configured in 
 
 ### Typed exports
 
-The package re-exports the async client plus enums and models from `desearch_py.models`, including `Tool`, `WebTool`, `DateFilter`, `ResultType`, `Sort`, `ResponseData`, `TwitterScraperTweet`, `WebSearchResponse`, `WebSearchResultsResponse`, `XLinksSearchResponse`, `XRetweetersResponse`, `XUserPostsResponse`, and `XTrendsResponse`.
+The package re-exports the async client plus enums and models from `desearch_py.models`, including `Tool`, `WebTool`, `DateFilter`, `ResultType`, `Sort`, `ResponseData`, `DesearchCostMetadata`, `DesearchResponse`, `TwitterScraperTweet`, `WebSearchResponse`, `WebSearchResultsResponse`, `XLinksSearchResponse`, `XRetweetersResponse`, `XUserPostsResponse`, and `XTrendsResponse`.
 
 ## Architecture overview
 
@@ -138,7 +170,8 @@ Key design decisions visible in code:
 - the HTTP session is created lazily on first use
 - auth is sent as `Authorization: <api_key>` with no `Bearer` prefix
 - most requests share a single helper with a fixed 120 second timeout
-- `x_posts_by_urls` and `web_crawl` bypass that shared helper and make direct requests
+- successful responses can opt in to a `DesearchResponse` wrapper with parsed cost metadata from response headers
+- `x_posts_by_urls` and `web_crawl` bypass that shared helper and make direct requests, but still support the metadata wrapper
 - some endpoints fall back to raw `dict` values instead of failing model parsing
 - `ai_search` always sends `"streaming": False`
 

--- a/desearch_py/__init__.py
+++ b/desearch_py/__init__.py
@@ -1,6 +1,8 @@
 from .api import Desearch
 from .models import (
     DateFilter,
+    DesearchCostMetadata,
+    DesearchResponse,
     HTTPValidationError,
     InternalServerErrorResponse,
     MediaSize,
@@ -52,6 +54,8 @@ from .models import (
 __all__ = [
     "Desearch",
     "DateFilter",
+    "DesearchCostMetadata",
+    "DesearchResponse",
     "HTTPValidationError",
     "InternalServerErrorResponse",
     "MediaSize",

--- a/desearch_py/api.py
+++ b/desearch_py/api.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
 import logging
-from typing import Any, AsyncIterator, Dict, List, Optional, Union
+import math
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import aiohttp
 
 from .models import (
+    DesearchCostMetadata,
+    DesearchResponse,
     ResponseData,
     WebSearchResponse,
     XLinksSearchResponse,
@@ -58,17 +61,76 @@ class Desearch:
         if self.client and not self.client.closed:
             await self.client.close()
 
-    async def _handle_request(self, method: str, url: str, **kwargs: Any) -> Any:
+    @staticmethod
+    def _parse_float(value: Optional[str]) -> Optional[float]:
+        if value is None:
+            return None
+        try:
+            parsed = float(value)
+        except (TypeError, ValueError):
+            return None
+        if not math.isfinite(parsed):
+            return None
+        return parsed
+
+    @staticmethod
+    def _parse_int(value: Optional[str]) -> Optional[int]:
+        if value is None:
+            return None
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return None
+
+    @classmethod
+    def _extract_cost_metadata(cls, headers: Any) -> DesearchCostMetadata:
+        """Parse optional Desearch per-request cost metadata from response headers."""
+        return DesearchCostMetadata(
+            cost_cents=cls._parse_float(headers.get("X-Desearch-Cost-Cents")),
+            usage_count=cls._parse_int(headers.get("X-Desearch-Usage-Count")),
+            service=headers.get("X-Desearch-Service"),
+            currency=headers.get("X-Desearch-Currency"),
+        )
+
+    @staticmethod
+    def _split_response(
+        result: Any, include_metadata: bool
+    ) -> Tuple[Any, Optional[DesearchCostMetadata]]:
+        if include_metadata and isinstance(result, DesearchResponse):
+            return result.data, result.metadata
+        return result, None
+
+    @staticmethod
+    def _with_metadata(
+        data: Any,
+        metadata: Optional[DesearchCostMetadata],
+        include_metadata: bool,
+    ) -> Any:
+        if include_metadata:
+            return DesearchResponse(
+                data=data, metadata=metadata or DesearchCostMetadata()
+            )
+        return data
+
+    async def _handle_request(
+        self,
+        method: str,
+        url: str,
+        *,
+        include_metadata: bool = False,
+        **kwargs: Any,
+    ) -> Any:
         """
         Send an HTTP request and return the parsed JSON response.
 
         Args:
             method (str): HTTP method (GET, POST, etc.).
             url (str): Full request URL.
+            include_metadata (bool): When true, wrap data with parsed response metadata.
             **kwargs: Additional arguments passed to the request.
 
         Returns:
-            Any: Parsed JSON response.
+            Any: Parsed JSON response, or DesearchResponse when metadata is requested.
 
         Raises:
             aiohttp.ClientResponseError: On HTTP error responses.
@@ -80,7 +142,9 @@ class Desearch:
                 method, url, timeout=aiohttp.ClientTimeout(total=120), **kwargs
             ) as response:
                 response.raise_for_status()
-                return await response.json()
+                metadata = self._extract_cost_metadata(response.headers)
+                data = await response.json()
+                return self._with_metadata(data, metadata, include_metadata)
         except aiohttp.ClientResponseError as e:
             logger.error("HTTP error %s for %s %s: %s", e.status, method, url, e.message)
             raise
@@ -99,7 +163,9 @@ class Desearch:
         system_message: Optional[str] = None,
         scoring_system_message: Optional[str] = None,
         count: Optional[int] = None,
-    ) -> Union[ResponseData, Dict[str, Any]]:
+        *,
+        include_metadata: bool = False,
+    ) -> Union[ResponseData, Dict[str, Any], DesearchResponse[Union[ResponseData, Dict[str, Any]]]]:
         """
         AI-powered multi-source contextual search.
 
@@ -135,20 +201,26 @@ class Desearch:
             if v is not None
         }
 
-        data = await self._handle_request("POST", url, json=payload)
+        result = await self._handle_request(
+            "POST", url, json=payload, include_metadata=include_metadata
+        )
+        data, metadata = self._split_response(result, include_metadata)
+        parsed_data = data
         if isinstance(data, dict):
             try:
-                return ResponseData(**data)
+                parsed_data = ResponseData(**data)
             except Exception:
-                return data
-        return data
+                parsed_data = data
+        return self._with_metadata(parsed_data, metadata, include_metadata)
 
     async def ai_web_links_search(
         self,
         prompt: str,
         tools: List[str],
         count: Optional[int] = None,
-    ) -> WebSearchResponse:
+        *,
+        include_metadata: bool = False,
+    ) -> Union[WebSearchResponse, DesearchResponse[WebSearchResponse]]:
         """
         Search for raw links across web sources using AI.
 
@@ -170,14 +242,19 @@ class Desearch:
             }.items()
             if v is not None
         }
-        data = await self._handle_request("POST", url, json=payload)
-        return WebSearchResponse(**data)
+        result = await self._handle_request(
+            "POST", url, json=payload, include_metadata=include_metadata
+        )
+        data, metadata = self._split_response(result, include_metadata)
+        return self._with_metadata(WebSearchResponse(**data), metadata, include_metadata)
 
     async def ai_x_links_search(
         self,
         prompt: str,
         count: Optional[int] = None,
-    ) -> XLinksSearchResponse:
+        *,
+        include_metadata: bool = False,
+    ) -> Union[XLinksSearchResponse, DesearchResponse[XLinksSearchResponse]]:
         """
         Search for X (Twitter) post links matching a prompt using AI.
 
@@ -197,8 +274,11 @@ class Desearch:
             }.items()
             if v is not None
         }
-        data = await self._handle_request("POST", url, json=payload)
-        return XLinksSearchResponse(**data)
+        result = await self._handle_request(
+            "POST", url, json=payload, include_metadata=include_metadata
+        )
+        data, metadata = self._split_response(result, include_metadata)
+        return self._with_metadata(XLinksSearchResponse(**data), metadata, include_metadata)
 
     async def x_search(
         self,
@@ -217,7 +297,9 @@ class Desearch:
         min_replies: Optional[Union[int, str]] = None,
         min_likes: Optional[Union[int, str]] = None,
         count: Optional[int] = 20,
-    ) -> Union[List[TwitterScraperTweet], Dict[str, Any]]:
+        *,
+        include_metadata: bool = False,
+    ) -> Union[List[TwitterScraperTweet], Dict[str, Any], DesearchResponse[Union[List[TwitterScraperTweet], Dict[str, Any]]]]:
         """
         Search X (Twitter) with extensive filtering options.
 
@@ -263,15 +345,21 @@ class Desearch:
             }.items()
             if v is not None
         }
-        data = await self._handle_request("GET", url, params=params)
+        result = await self._handle_request(
+            "GET", url, params=params, include_metadata=include_metadata
+        )
+        data, metadata = self._split_response(result, include_metadata)
+        parsed_data = data
         if isinstance(data, list):
-            return [TwitterScraperTweet(**item) for item in data]
-        return data
+            parsed_data = [TwitterScraperTweet(**item) for item in data]
+        return self._with_metadata(parsed_data, metadata, include_metadata)
 
     async def x_posts_by_urls(
         self,
         urls: List[str],
-    ) -> List[TwitterScraperTweet]:
+        *,
+        include_metadata: bool = False,
+    ) -> Union[List[TwitterScraperTweet], DesearchResponse[List[TwitterScraperTweet]]]:
         """
         Fetch full post data for a list of X (Twitter) post URLs.
 
@@ -289,6 +377,7 @@ class Desearch:
                 "GET", url, params=params, timeout=aiohttp.ClientTimeout(total=120)
             ) as response:
                 response.raise_for_status()
+                metadata = self._extract_cost_metadata(response.headers)
                 data = await response.json()
         except aiohttp.ClientResponseError as e:
             logger.error("HTTP error %s for GET %s: %s", e.status, url, e.message)
@@ -296,12 +385,15 @@ class Desearch:
         except aiohttp.ClientError as e:
             logger.error("Client error for GET %s: %s", url, str(e))
             raise
-        return [TwitterScraperTweet(**item) for item in data]
+        parsed_data = [TwitterScraperTweet(**item) for item in data]
+        return self._with_metadata(parsed_data, metadata, include_metadata)
 
     async def x_post_by_id(
         self,
         id: str,
-    ) -> TwitterScraperTweet:
+        *,
+        include_metadata: bool = False,
+    ) -> Union[TwitterScraperTweet, DesearchResponse[TwitterScraperTweet]]:
         """
         Fetch a single X (Twitter) post by its unique ID.
 
@@ -313,15 +405,20 @@ class Desearch:
         """
         url = f"{self.base_url}/twitter/post"
         params = {"id": id}
-        data = await self._handle_request("GET", url, params=params)
-        return TwitterScraperTweet(**data)
+        result = await self._handle_request(
+            "GET", url, params=params, include_metadata=include_metadata
+        )
+        data, metadata = self._split_response(result, include_metadata)
+        return self._with_metadata(TwitterScraperTweet(**data), metadata, include_metadata)
 
     async def x_posts_by_user(
         self,
         user: str,
         query: Optional[str] = None,
         count: Optional[int] = None,
-    ) -> Union[List[TwitterScraperTweet], Dict[str, Any]]:
+        *,
+        include_metadata: bool = False,
+    ) -> Union[List[TwitterScraperTweet], Dict[str, Any], DesearchResponse[Union[List[TwitterScraperTweet], Dict[str, Any]]]]:
         """
         Search X (Twitter) posts by a specific user with optional keyword filtering.
 
@@ -343,16 +440,22 @@ class Desearch:
             }.items()
             if v is not None
         }
-        data = await self._handle_request("GET", url, params=params)
+        result = await self._handle_request(
+            "GET", url, params=params, include_metadata=include_metadata
+        )
+        data, metadata = self._split_response(result, include_metadata)
+        parsed_data = data
         if isinstance(data, list):
-            return [TwitterScraperTweet(**item) for item in data]
-        return data
+            parsed_data = [TwitterScraperTweet(**item) for item in data]
+        return self._with_metadata(parsed_data, metadata, include_metadata)
 
     async def x_post_retweeters(
         self,
         id: str,
         cursor: Optional[str] = None,
-    ) -> XRetweetersResponse:
+        *,
+        include_metadata: bool = False,
+    ) -> Union[XRetweetersResponse, DesearchResponse[XRetweetersResponse]]:
         """
         Retrieve the list of users who retweeted a specific post.
 
@@ -372,14 +475,19 @@ class Desearch:
             }.items()
             if v is not None
         }
-        data = await self._handle_request("GET", url, params=params)
-        return XRetweetersResponse(**data)
+        result = await self._handle_request(
+            "GET", url, params=params, include_metadata=include_metadata
+        )
+        data, metadata = self._split_response(result, include_metadata)
+        return self._with_metadata(XRetweetersResponse(**data), metadata, include_metadata)
 
     async def x_user_posts(
         self,
         username: str,
         cursor: Optional[str] = None,
-    ) -> XUserPostsResponse:
+        *,
+        include_metadata: bool = False,
+    ) -> Union[XUserPostsResponse, DesearchResponse[XUserPostsResponse]]:
         """
         Retrieve a user's timeline posts by their username.
 
@@ -399,15 +507,20 @@ class Desearch:
             }.items()
             if v is not None
         }
-        data = await self._handle_request("GET", url, params=params)
-        return XUserPostsResponse(**data)
+        result = await self._handle_request(
+            "GET", url, params=params, include_metadata=include_metadata
+        )
+        data, metadata = self._split_response(result, include_metadata)
+        return self._with_metadata(XUserPostsResponse(**data), metadata, include_metadata)
 
     async def x_user_replies(
         self,
         user: str,
         count: Optional[int] = None,
         query: Optional[str] = None,
-    ) -> Union[List[TwitterScraperTweet], Dict[str, Any]]:
+        *,
+        include_metadata: bool = False,
+    ) -> Union[List[TwitterScraperTweet], Dict[str, Any], DesearchResponse[Union[List[TwitterScraperTweet], Dict[str, Any]]]]:
         """
         Fetch tweets and replies posted by a specific user.
 
@@ -429,17 +542,23 @@ class Desearch:
             }.items()
             if v is not None
         }
-        data = await self._handle_request("GET", url, params=params)
+        result = await self._handle_request(
+            "GET", url, params=params, include_metadata=include_metadata
+        )
+        data, metadata = self._split_response(result, include_metadata)
+        parsed_data = data
         if isinstance(data, list):
-            return [TwitterScraperTweet(**item) for item in data]
-        return data
+            parsed_data = [TwitterScraperTweet(**item) for item in data]
+        return self._with_metadata(parsed_data, metadata, include_metadata)
 
     async def x_post_replies(
         self,
         post_id: str,
         count: Optional[int] = None,
         query: Optional[str] = None,
-    ) -> Union[List[TwitterScraperTweet], Dict[str, Any]]:
+        *,
+        include_metadata: bool = False,
+    ) -> Union[List[TwitterScraperTweet], Dict[str, Any], DesearchResponse[Union[List[TwitterScraperTweet], Dict[str, Any]]]]:
         """
         Fetch replies to a specific X (Twitter) post by its post ID.
 
@@ -461,16 +580,22 @@ class Desearch:
             }.items()
             if v is not None
         }
-        data = await self._handle_request("GET", url, params=params)
+        result = await self._handle_request(
+            "GET", url, params=params, include_metadata=include_metadata
+        )
+        data, metadata = self._split_response(result, include_metadata)
+        parsed_data = data
         if isinstance(data, list):
-            return [TwitterScraperTweet(**item) for item in data]
-        return data
+            parsed_data = [TwitterScraperTweet(**item) for item in data]
+        return self._with_metadata(parsed_data, metadata, include_metadata)
 
     async def x_trends(
         self,
         woeid: int,
         count: Optional[int] = None,
-    ) -> XTrendsResponse:
+        *,
+        include_metadata: bool = False,
+    ) -> Union[XTrendsResponse, DesearchResponse[XTrendsResponse]]:
         """
         Retrieve trending topics on X for a given location using its WOEID.
 
@@ -490,14 +615,19 @@ class Desearch:
             }.items()
             if v is not None
         }
-        data = await self._handle_request("GET", url, params=params)
-        return XTrendsResponse(**data)
+        result = await self._handle_request(
+            "GET", url, params=params, include_metadata=include_metadata
+        )
+        data, metadata = self._split_response(result, include_metadata)
+        return self._with_metadata(XTrendsResponse(**data), metadata, include_metadata)
 
     async def web_search(
         self,
         query: str,
         start: Optional[int] = 0,
-    ) -> WebSearchResultsResponse:
+        *,
+        include_metadata: bool = False,
+    ) -> Union[WebSearchResultsResponse, DesearchResponse[WebSearchResultsResponse]]:
         """
         SERP web search returning paginated web search results.
 
@@ -517,14 +647,19 @@ class Desearch:
             }.items()
             if v is not None
         }
-        data = await self._handle_request("GET", url, params=params)
-        return WebSearchResultsResponse(**data)
+        result = await self._handle_request(
+            "GET", url, params=params, include_metadata=include_metadata
+        )
+        data, metadata = self._split_response(result, include_metadata)
+        return self._with_metadata(WebSearchResultsResponse(**data), metadata, include_metadata)
 
     async def web_crawl(
         self,
         url: str,
         format: Optional[str] = "text",
-    ) -> str:
+        *,
+        include_metadata: bool = False,
+    ) -> Union[str, DesearchResponse[str]]:
         """
         Crawl a URL and return its content as plain text or HTML.
 
@@ -550,7 +685,9 @@ class Desearch:
                 "GET", request_url, params=params, timeout=aiohttp.ClientTimeout(total=120)
             ) as response:
                 response.raise_for_status()
-                return await response.text()
+                metadata = self._extract_cost_metadata(response.headers)
+                data = await response.text()
+                return self._with_metadata(data, metadata, include_metadata)
         except aiohttp.ClientResponseError as e:
             logger.error("HTTP error %s for GET %s: %s", e.status, request_url, e.message)
             raise

--- a/desearch_py/models.py
+++ b/desearch_py/models.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 from enum import Enum
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, Generic, List, Optional, TypeVar, Union
 
 from pydantic import BaseModel, ConfigDict
+
+T = TypeVar("T")
 
 # ─── Enums ────────────────────────────────────────────────────────────────────
 
@@ -332,6 +334,26 @@ class WebSearchResultsResponse(BaseModel):
     data: List[WebSearchResultItem]
 
 
+
+
+# ─── Response Metadata Models ────────────────────────────────────────────────
+
+
+class DesearchCostMetadata(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    cost_cents: Optional[float] = None
+    usage_count: Optional[int] = None
+    service: Optional[str] = None
+    currency: Optional[str] = None
+
+
+class DesearchResponse(BaseModel, Generic[T]):
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    data: T
+    metadata: DesearchCostMetadata
+
 # ─── AI Search Response Model ────────────────────────────────────────────────
 
 
@@ -346,6 +368,10 @@ class ResponseData(BaseModel):
     text: Optional[str] = None
     miner_link_scores: Optional[Dict[str, str]] = None
     completion: Optional[str] = None
+    cost_cents: Optional[float] = None
+    usage_count: Optional[int] = None
+    service: Optional[str] = None
+    currency: Optional[str] = None
 
 
 # ─── X Links Search Response ─────────────────────────────────────────────────

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -65,6 +65,7 @@ Consequence:
 - a hardcoded `aiohttp.ClientTimeout(total=120)`
 - `response.raise_for_status()`
 - JSON decoding
+- optional cost metadata extraction from `X-Desearch-*` response headers
 - error logging before re-raise
 
 This keeps the repo small, but it also means the same timeout and JSON expectations are applied broadly.
@@ -82,6 +83,7 @@ Tradeoff:
 
 - these methods can support their special request shapes cleanly
 - request/error logic is duplicated, so future transport changes must be updated in more than one place
+- both paths still parse the same optional response cost metadata when callers pass `include_metadata=True`
 
 ## Data model design
 
@@ -101,6 +103,13 @@ Most methods instantiate `pydantic` models directly, but several methods return 
 
 That pattern shows the SDK favors resilience over rigid typing for unstable or miner-shaped responses.
 
+
+### Optional response metadata wrapper
+
+Every public endpoint keeps its existing default return shape. For example, `await client.web_crawl(url="https://desearch.ai")` still returns raw text and `await client.x_search(query="desearch")` still returns the parsed tweet list or raw dictionary.
+
+Callers that pass `include_metadata=True` receive `DesearchResponse[data, metadata]` instead. The `data` field contains the same payload the method would have returned by default, and `metadata` is parsed from the same response headers: `X-Desearch-Cost-Cents`, `X-Desearch-Usage-Count`, `X-Desearch-Service`, and `X-Desearch-Currency`. Numeric parse failures become `None` so successful API responses are not turned into SDK errors.
+
 ## Public API boundary
 
 `desearch_py/__init__.py` is the package boundary for consumers. It re-exports:
@@ -108,6 +117,7 @@ That pattern shows the SDK favors resilience over rigid typing for unstable or m
 - `Desearch`
 - enums such as `Tool`, `WebTool`, `DateFilter`, `ResultType`, `Sort`
 - response models
+- response metadata wrapper models
 - error models
 - X/Twitter entity models
 

--- a/tests/test_response_metadata.py
+++ b/tests/test_response_metadata.py
@@ -1,0 +1,158 @@
+import unittest
+
+from desearch_py import Desearch, DesearchResponse, ResponseData, TwitterScraperTweet
+
+
+TWEET = {
+    "id": "1",
+    "text": "hello",
+    "reply_count": 0,
+    "retweet_count": 0,
+    "like_count": 1,
+    "quote_count": 0,
+    "bookmark_count": 0,
+    "created_at": "2026-05-07T00:00:00Z",
+}
+
+
+class FakeResponse:
+    def __init__(self, *, json_data=None, text_data="", headers=None):
+        self._json_data = json_data
+        self._text_data = text_data
+        self.headers = headers or {}
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    def raise_for_status(self):
+        return None
+
+    async def json(self):
+        return self._json_data
+
+    async def text(self):
+        return self._text_data
+
+
+class FakeSession:
+    closed = False
+
+    def __init__(self, responses):
+        self._responses = list(responses)
+        self.requests = []
+
+    def request(self, method, url, **kwargs):
+        self.requests.append((method, url, kwargs))
+        return self._responses.pop(0)
+
+    async def close(self):
+        self.closed = True
+
+
+class ResponseMetadataTests(unittest.IsolatedAsyncioTestCase):
+    def make_client(self, *responses):
+        client = Desearch(api_key="test-key", base_url="https://example.test")
+        client.client = FakeSession(responses)
+        return client
+
+    async def test_default_calls_keep_original_json_object_list_and_text_shapes(self):
+        ai_client = self.make_client(
+            FakeResponse(
+                json_data={"text": "answer"},
+                headers={"X-Desearch-Cost-Cents": "1.25"},
+            )
+        )
+        ai_result = await ai_client.ai_search(prompt="q", tools=["web"])
+        self.assertIsInstance(ai_result, ResponseData)
+        self.assertNotIsInstance(ai_result, DesearchResponse)
+        self.assertEqual(ai_result.text, "answer")
+
+        x_client = self.make_client(
+            FakeResponse(
+                json_data=[TWEET],
+                headers={"X-Desearch-Cost-Cents": "1.25"},
+            )
+        )
+        x_result = await x_client.x_search(query="desearch")
+        self.assertIsInstance(x_result, list)
+        self.assertIsInstance(x_result[0], TwitterScraperTweet)
+
+        crawl_client = self.make_client(
+            FakeResponse(
+                text_data="plain crawl text",
+                headers={"X-Desearch-Cost-Cents": "1.25"},
+            )
+        )
+        crawl_result = await crawl_client.web_crawl(url="https://desearch.ai")
+        self.assertEqual(crawl_result, "plain crawl text")
+
+    async def test_include_metadata_wraps_data_and_parsed_response_headers(self):
+        headers = {
+            "X-Desearch-Cost-Cents": "2.5",
+            "X-Desearch-Usage-Count": "7",
+            "X-Desearch-Service": "twitter",
+            "X-Desearch-Currency": "USD",
+        }
+        client = self.make_client(FakeResponse(json_data=[TWEET], headers=headers))
+
+        result = await client.x_search(query="desearch", include_metadata=True)
+
+        self.assertIsInstance(result, DesearchResponse)
+        self.assertIsInstance(result.data, list)
+        self.assertIsInstance(result.data[0], TwitterScraperTweet)
+        self.assertEqual(result.metadata.cost_cents, 2.5)
+        self.assertEqual(result.metadata.usage_count, 7)
+        self.assertEqual(result.metadata.service, "twitter")
+        self.assertEqual(result.metadata.currency, "USD")
+
+    async def test_custom_json_and_text_paths_support_include_metadata(self):
+        headers = {
+            "X-Desearch-Cost-Cents": "0.5",
+            "X-Desearch-Usage-Count": "1",
+            "X-Desearch-Service": "crawl",
+            "X-Desearch-Currency": "USD",
+        }
+        urls_client = self.make_client(FakeResponse(json_data=[TWEET], headers=headers))
+        urls_result = await urls_client.x_posts_by_urls(
+            urls=["https://x.com/desearch/status/1"], include_metadata=True
+        )
+        self.assertIsInstance(urls_result, DesearchResponse)
+        self.assertIsInstance(urls_result.data[0], TwitterScraperTweet)
+        self.assertEqual(urls_result.metadata.cost_cents, 0.5)
+
+        crawl_client = self.make_client(FakeResponse(text_data="content", headers=headers))
+        crawl_result = await crawl_client.web_crawl(
+            url="https://desearch.ai", include_metadata=True
+        )
+        self.assertIsInstance(crawl_result, DesearchResponse)
+        self.assertEqual(crawl_result.data, "content")
+        self.assertEqual(crawl_result.metadata.service, "crawl")
+
+    async def test_missing_or_malformed_metadata_headers_do_not_break_successful_calls(self):
+        client = self.make_client(
+            FakeResponse(
+                json_data={"text": "ok"},
+                headers={
+                    "X-Desearch-Cost-Cents": "NaN",
+                    "X-Desearch-Usage-Count": "also-bad",
+                },
+            )
+        )
+
+        result = await client.ai_search(
+            prompt="q", tools=["web"], include_metadata=True
+        )
+
+        self.assertIsInstance(result, DesearchResponse)
+        self.assertEqual(result.data.text, "ok")
+        self.assertIsNone(result.metadata.cost_cents)
+        self.assertIsNone(result.metadata.usage_count)
+        self.assertIsNone(result.metadata.service)
+        self.assertIsNone(result.metadata.currency)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Files changed: desearch_py/api.py added keyword-only include_metadata=False across all public async endpoints, shared X-Desearch-* header parsing, DesearchResponse wrapping, and coverage for custom x_posts_by_urls/web_crawl paths; desearch_py/models.py added DesearchCostMetadata, DesearchResponse, and optional cost body fields on ResponseData; desearch_py/__init__.py exports new metadata types; README.md and docs/architecture.md document default behavior plus opted-in cost metadata; tests/test_response_metadata.py added async unittest coverage. Tests added: default JSON object/list/text shapes remain unchanged; include_metadata=True returns data plus parsed X-Desearch-Cost-Cents, X-Desearch-Usage-Count, X-Desearch-Service, X-Desearch-Currency; custom JSON/text paths support metadata; missing/malformed numeric headers return None without breaking successful calls. Verification: poetry run python -m compileall desearch_py passed; poetry run python -m unittest discover -s tests -v passed 4 tests; poetry build passed and built sdist/wheel. Commit: e070d26 feat(#1243): add opt-in response cost metadata. Noteworthy: no extra API/pricing/billing requests were added; metadata is read only from the same response object; branch is feature/task-1243 and dispatcher will open the PR.

---
Task: #1243 — Add opt-in response cost metadata support to Desearch Python SDK
Opened automatically by mission-control dispatcher.