### PR TITLE
Update Python SDK metadata contract from cost_cents to cost_usd

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,13 +69,13 @@ response = await client.ai_search(
 )
 
 print(response.data.text)
-print(response.metadata.cost_cents)
+print(response.metadata.cost_usd)
 print(response.metadata.usage_count)
 print(response.metadata.service)
 print(response.metadata.currency)
 ```
 
-The SDK reads metadata from the same API response headers (`X-Desearch-Cost-Cents`, `X-Desearch-Usage-Count`, `X-Desearch-Service`, and `X-Desearch-Currency`). Missing or malformed numeric headers are exposed as `None` instead of breaking a successful API call.
+The SDK reads metadata from the same API response headers (`X-Desearch-Cost-Usd`, for example `0.00015`, plus `X-Desearch-Usage-Count`, `X-Desearch-Service`, and `X-Desearch-Currency`). Missing or malformed numeric headers are exposed as `None` instead of breaking a successful API call.
 
 ### Reuse the client manually
 

--- a/desearch_py/api.py
+++ b/desearch_py/api.py
@@ -86,7 +86,7 @@ class Desearch:
     def _extract_cost_metadata(cls, headers: Any) -> DesearchCostMetadata:
         """Parse optional Desearch per-request cost metadata from response headers."""
         return DesearchCostMetadata(
-            cost_cents=cls._parse_float(headers.get("X-Desearch-Cost-Cents")),
+            cost_usd=cls._parse_float(headers.get("X-Desearch-Cost-Usd")),
             usage_count=cls._parse_int(headers.get("X-Desearch-Usage-Count")),
             service=headers.get("X-Desearch-Service"),
             currency=headers.get("X-Desearch-Currency"),

--- a/desearch_py/models.py
+++ b/desearch_py/models.py
@@ -342,7 +342,7 @@ class WebSearchResultsResponse(BaseModel):
 class DesearchCostMetadata(BaseModel):
     model_config = ConfigDict(extra="allow")
 
-    cost_cents: Optional[float] = None
+    cost_usd: Optional[float] = None
     usage_count: Optional[int] = None
     service: Optional[str] = None
     currency: Optional[str] = None
@@ -368,7 +368,7 @@ class ResponseData(BaseModel):
     text: Optional[str] = None
     miner_link_scores: Optional[Dict[str, str]] = None
     completion: Optional[str] = None
-    cost_cents: Optional[float] = None
+    cost_usd: Optional[float] = None
     usage_count: Optional[int] = None
     service: Optional[str] = None
     currency: Optional[str] = None

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -108,7 +108,7 @@ That pattern shows the SDK favors resilience over rigid typing for unstable or m
 
 Every public endpoint keeps its existing default return shape. For example, `await client.web_crawl(url="https://desearch.ai")` still returns raw text and `await client.x_search(query="desearch")` still returns the parsed tweet list or raw dictionary.
 
-Callers that pass `include_metadata=True` receive `DesearchResponse[data, metadata]` instead. The `data` field contains the same payload the method would have returned by default, and `metadata` is parsed from the same response headers: `X-Desearch-Cost-Cents`, `X-Desearch-Usage-Count`, `X-Desearch-Service`, and `X-Desearch-Currency`. Numeric parse failures become `None` so successful API responses are not turned into SDK errors.
+Callers that pass `include_metadata=True` receive `DesearchResponse[data, metadata]` instead. The `data` field contains the same payload the method would have returned by default, and `metadata` is parsed from the same response headers: `X-Desearch-Cost-Usd` (for example `0.00015`), `X-Desearch-Usage-Count`, `X-Desearch-Service`, and `X-Desearch-Currency`. Numeric parse failures become `None` so successful API responses are not turned into SDK errors.
 
 ## Public API boundary
 

--- a/tests/test_response_metadata.py
+++ b/tests/test_response_metadata.py
@@ -62,7 +62,7 @@ class ResponseMetadataTests(unittest.IsolatedAsyncioTestCase):
         ai_client = self.make_client(
             FakeResponse(
                 json_data={"text": "answer"},
-                headers={"X-Desearch-Cost-Cents": "1.25"},
+                headers={"X-Desearch-Cost-Usd": "0.00015"},
             )
         )
         ai_result = await ai_client.ai_search(prompt="q", tools=["web"])
@@ -73,7 +73,7 @@ class ResponseMetadataTests(unittest.IsolatedAsyncioTestCase):
         x_client = self.make_client(
             FakeResponse(
                 json_data=[TWEET],
-                headers={"X-Desearch-Cost-Cents": "1.25"},
+                headers={"X-Desearch-Cost-Usd": "0.00015"},
             )
         )
         x_result = await x_client.x_search(query="desearch")
@@ -83,7 +83,7 @@ class ResponseMetadataTests(unittest.IsolatedAsyncioTestCase):
         crawl_client = self.make_client(
             FakeResponse(
                 text_data="plain crawl text",
-                headers={"X-Desearch-Cost-Cents": "1.25"},
+                headers={"X-Desearch-Cost-Usd": "0.00015"},
             )
         )
         crawl_result = await crawl_client.web_crawl(url="https://desearch.ai")
@@ -91,7 +91,7 @@ class ResponseMetadataTests(unittest.IsolatedAsyncioTestCase):
 
     async def test_include_metadata_wraps_data_and_parsed_response_headers(self):
         headers = {
-            "X-Desearch-Cost-Cents": "2.5",
+            "X-Desearch-Cost-Usd": "0.00025",
             "X-Desearch-Usage-Count": "7",
             "X-Desearch-Service": "twitter",
             "X-Desearch-Currency": "USD",
@@ -103,14 +103,14 @@ class ResponseMetadataTests(unittest.IsolatedAsyncioTestCase):
         self.assertIsInstance(result, DesearchResponse)
         self.assertIsInstance(result.data, list)
         self.assertIsInstance(result.data[0], TwitterScraperTweet)
-        self.assertEqual(result.metadata.cost_cents, 2.5)
+        self.assertEqual(result.metadata.cost_usd, 0.00025)
         self.assertEqual(result.metadata.usage_count, 7)
         self.assertEqual(result.metadata.service, "twitter")
         self.assertEqual(result.metadata.currency, "USD")
 
     async def test_custom_json_and_text_paths_support_include_metadata(self):
         headers = {
-            "X-Desearch-Cost-Cents": "0.5",
+            "X-Desearch-Cost-Usd": "0.00005",
             "X-Desearch-Usage-Count": "1",
             "X-Desearch-Service": "crawl",
             "X-Desearch-Currency": "USD",
@@ -121,7 +121,7 @@ class ResponseMetadataTests(unittest.IsolatedAsyncioTestCase):
         )
         self.assertIsInstance(urls_result, DesearchResponse)
         self.assertIsInstance(urls_result.data[0], TwitterScraperTweet)
-        self.assertEqual(urls_result.metadata.cost_cents, 0.5)
+        self.assertEqual(urls_result.metadata.cost_usd, 0.00005)
 
         crawl_client = self.make_client(FakeResponse(text_data="content", headers=headers))
         crawl_result = await crawl_client.web_crawl(
@@ -136,7 +136,7 @@ class ResponseMetadataTests(unittest.IsolatedAsyncioTestCase):
             FakeResponse(
                 json_data={"text": "ok"},
                 headers={
-                    "X-Desearch-Cost-Cents": "NaN",
+                    "X-Desearch-Cost-Usd": "NaN",
                     "X-Desearch-Usage-Count": "also-bad",
                 },
             )
@@ -148,7 +148,7 @@ class ResponseMetadataTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertIsInstance(result, DesearchResponse)
         self.assertEqual(result.data.text, "ok")
-        self.assertIsNone(result.metadata.cost_cents)
+        self.assertIsNone(result.metadata.cost_usd)
         self.assertIsNone(result.metadata.usage_count)
         self.assertIsNone(result.metadata.service)
         self.assertIsNone(result.metadata.currency)


### PR DESCRIPTION
## Problem
The Python SDK still exposed request-cost metadata using the old cents contract, while Objective #90 makes USD metadata canonical via `X-Desearch-Cost-Usd` and `cost_usd`.

## Root cause
The existing metadata parser, compatible response models, tests, README, and architecture docs were written against `X-Desearch-Cost-Cents` / `cost_cents`, so SDK consumers opting into metadata would see the deprecated field name instead of the canonical USD contract.

## Fix
Updated the SDK metadata contract to USD while preserving default return shapes:
- `desearch_py/api.py`: parses `X-Desearch-Cost-Usd` into `DesearchCostMetadata.cost_usd`.
- `desearch_py/models.py`: exposes `cost_usd` on metadata-compatible response models instead of `cost_cents`.
- `tests/test_response_metadata.py`: updated metadata tests to assert USD header parsing, malformed/missing USD handling, and unchanged default return shapes.
- `README.md`: documents `include_metadata=True` with `response.metadata.cost_usd` and `X-Desearch-Cost-Usd` example `0.00015`.
- `docs/architecture.md`: documents USD as the canonical response metadata header and field.

## Validation
- `PYTHONPATH=. uv run pytest -q` — passed: 4 tests.
- `PYTHONPATH=. uv run --with build python -m build` — passed: built sdist and wheel successfully.
- `grep -RIn "X-Desearch-Cost-Cents\|cost_cents" README.md docs tests desearch_py || true` — confirmed no canonical cents references remain in SDK code, tests, README, or docs.
- `git diff origin/objective/o-90-cost-usd-response-metadata...HEAD --stat` — confirmed non-empty committed diff across README, API, models, architecture docs, and response metadata tests.

## Known gaps/blockers
None.

## Production expectation
After merge into `objective/o-90-cost-usd-response-metadata`, Python SDK callers who opt into metadata should receive USD request-cost metadata via `cost_usd`; callers that do not pass `include_metadata=True` should continue receiving the same raw payload shapes as before. Main/prod/release remains gated on explicit Giga approval.

---
Task: #1738 — Update Python SDK metadata contract from cost_cents to cost_usd
Opened automatically by mission-control dispatcher.