### PR TITLE
Promote and release O-90 USD metadata in desearch.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,13 +69,13 @@ response = await client.ai_search(
 )
 
 print(response.data.text)
-print(response.metadata.cost_cents)
+print(response.metadata.cost_usd)
 print(response.metadata.usage_count)
 print(response.metadata.service)
 print(response.metadata.currency)
 ```
 
-The SDK reads metadata from the same API response headers (`X-Desearch-Cost-Cents`, `X-Desearch-Usage-Count`, `X-Desearch-Service`, and `X-Desearch-Currency`). Missing or malformed numeric headers are exposed as `None` instead of breaking a successful API call.
+The SDK reads metadata from the same API response headers (`X-Desearch-Cost-Usd`, for example `0.00015`, plus `X-Desearch-Usage-Count`, `X-Desearch-Service`, and `X-Desearch-Currency`). Missing or malformed numeric headers are exposed as `None` instead of breaking a successful API call.
 
 ### Reuse the client manually
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Official async Python SDK for the Desearch API.
 
-`desearch-py` is a thin `aiohttp` client for the Desearch public API. It wraps search, X, and crawl endpoints behind a single async client class and returns `pydantic` models for most successful responses. The package metadata currently reports **version 1.2.0** and requires **Python 3.9+**.
+`desearch-py` is a thin `aiohttp` client for the Desearch public API. It wraps search, X, and crawl endpoints behind a single async client class and returns `pydantic` models for most successful responses. The package metadata currently reports **version 1.2.1** and requires **Python 3.9+**.
 
 ## Package purpose
 

--- a/desearch_py/api.py
+++ b/desearch_py/api.py
@@ -86,7 +86,7 @@ class Desearch:
     def _extract_cost_metadata(cls, headers: Any) -> DesearchCostMetadata:
         """Parse optional Desearch per-request cost metadata from response headers."""
         return DesearchCostMetadata(
-            cost_cents=cls._parse_float(headers.get("X-Desearch-Cost-Cents")),
+            cost_usd=cls._parse_float(headers.get("X-Desearch-Cost-Usd")),
             usage_count=cls._parse_int(headers.get("X-Desearch-Usage-Count")),
             service=headers.get("X-Desearch-Service"),
             currency=headers.get("X-Desearch-Currency"),

--- a/desearch_py/models.py
+++ b/desearch_py/models.py
@@ -342,7 +342,7 @@ class WebSearchResultsResponse(BaseModel):
 class DesearchCostMetadata(BaseModel):
     model_config = ConfigDict(extra="allow")
 
-    cost_cents: Optional[float] = None
+    cost_usd: Optional[float] = None
     usage_count: Optional[int] = None
     service: Optional[str] = None
     currency: Optional[str] = None
@@ -368,7 +368,7 @@ class ResponseData(BaseModel):
     text: Optional[str] = None
     miner_link_scores: Optional[Dict[str, str]] = None
     completion: Optional[str] = None
-    cost_cents: Optional[float] = None
+    cost_usd: Optional[float] = None
     usage_count: Optional[int] = None
     service: Optional[str] = None
     currency: Optional[str] = None

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -108,7 +108,7 @@ That pattern shows the SDK favors resilience over rigid typing for unstable or m
 
 Every public endpoint keeps its existing default return shape. For example, `await client.web_crawl(url="https://desearch.ai")` still returns raw text and `await client.x_search(query="desearch")` still returns the parsed tweet list or raw dictionary.
 
-Callers that pass `include_metadata=True` receive `DesearchResponse[data, metadata]` instead. The `data` field contains the same payload the method would have returned by default, and `metadata` is parsed from the same response headers: `X-Desearch-Cost-Cents`, `X-Desearch-Usage-Count`, `X-Desearch-Service`, and `X-Desearch-Currency`. Numeric parse failures become `None` so successful API responses are not turned into SDK errors.
+Callers that pass `include_metadata=True` receive `DesearchResponse[data, metadata]` instead. The `data` field contains the same payload the method would have returned by default, and `metadata` is parsed from the same response headers: `X-Desearch-Cost-Usd` (for example `0.00015`), `X-Desearch-Usage-Count`, `X-Desearch-Service`, and `X-Desearch-Currency`. Numeric parse failures become `None` so successful API responses are not turned into SDK errors.
 
 ## Public API boundary
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -130,8 +130,8 @@ Practical effect:
 
 The repo keeps both Poetry and setuptools metadata:
 
-- `pyproject.toml` names the package `desearch-py` and declares version `1.2.0`
-- `setup.py` packages the import module `desearch_py` and also declares version `1.2.0`
+- `pyproject.toml` names the package `desearch-py` and declares version `1.2.1`
+- `setup.py` packages the import module `desearch_py` and also declares version `1.2.1`
 
 This dual-metadata setup supports multiple install flows, but it creates a maintenance obligation: version and dependency drift between the two files would be a release bug.
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -2,7 +2,7 @@
 
 > Status key: ✅ working · ⚠️ degraded · ❌ broken · 🚧 in progress
 
-This inventory is derived from the current source in `desearch_py/api.py`, `desearch_py/models.py`, `pyproject.toml`, and `setup.py`. Current package version: **1.2.0**.
+This inventory is derived from the current source in `desearch_py/api.py`, `desearch_py/models.py`, `pyproject.toml`, and `setup.py`. Current package version: **1.2.1**.
 
 ## Overview
 
@@ -100,9 +100,9 @@ The SDK exposes one async client class, `Desearch`, plus a large set of typed mo
 
 | Surface | Status | Notes |
 |---|---|---|
-| Poetry metadata in `pyproject.toml` | ✅ | Declares package name `desearch-py`, version `1.2.0`, and runtime deps. |
-| setuptools metadata in `setup.py` | ✅ | Declares import package `desearch_py`, version `1.2.0`, and package data. |
-| Version parity between Poetry and setuptools | ✅ | Both files currently declare `1.2.0`. |
+| Poetry metadata in `pyproject.toml` | ✅ | Declares package name `desearch-py`, version `1.2.1`, and runtime deps. |
+| setuptools metadata in `setup.py` | ✅ | Declares import package `desearch_py`, version `1.2.1`, and package data. |
+| Version parity between Poetry and setuptools | ✅ | Both files currently declare `1.2.1`. |
 | Sphinx source files | ✅ | `docs/conf.py`, `docs/index.rst`, `docs/Makefile`, and `docs/make.bat` are present. |
 | Sphinx branding correctness | ❌ | `docs/conf.py` and generated `docs/_build/` still carry legacy `datura-py` / `Leva` metadata. |
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ authors = ["Desearch AI <hello@desearch.ai>"]
 description = "Python SDK for Desearch API."
 name = "desearch-py"
 readme = "README.md"
-version = "1.2.0"
+version = "1.2.1"
 
 [tool.poetry.dependencies]
 aiohttp = ">=3.8"

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="desearch_py",
-    version="1.2.0",
+    version="1.2.1",
     description="A Python SDK for interacting with the Desearch API service.",
     author="Desearch",
     author_email="",

--- a/tests/test_response_metadata.py
+++ b/tests/test_response_metadata.py
@@ -62,7 +62,7 @@ class ResponseMetadataTests(unittest.IsolatedAsyncioTestCase):
         ai_client = self.make_client(
             FakeResponse(
                 json_data={"text": "answer"},
-                headers={"X-Desearch-Cost-Cents": "1.25"},
+                headers={"X-Desearch-Cost-Usd": "0.00015"},
             )
         )
         ai_result = await ai_client.ai_search(prompt="q", tools=["web"])
@@ -73,7 +73,7 @@ class ResponseMetadataTests(unittest.IsolatedAsyncioTestCase):
         x_client = self.make_client(
             FakeResponse(
                 json_data=[TWEET],
-                headers={"X-Desearch-Cost-Cents": "1.25"},
+                headers={"X-Desearch-Cost-Usd": "0.00015"},
             )
         )
         x_result = await x_client.x_search(query="desearch")
@@ -83,7 +83,7 @@ class ResponseMetadataTests(unittest.IsolatedAsyncioTestCase):
         crawl_client = self.make_client(
             FakeResponse(
                 text_data="plain crawl text",
-                headers={"X-Desearch-Cost-Cents": "1.25"},
+                headers={"X-Desearch-Cost-Usd": "0.00015"},
             )
         )
         crawl_result = await crawl_client.web_crawl(url="https://desearch.ai")
@@ -91,7 +91,7 @@ class ResponseMetadataTests(unittest.IsolatedAsyncioTestCase):
 
     async def test_include_metadata_wraps_data_and_parsed_response_headers(self):
         headers = {
-            "X-Desearch-Cost-Cents": "2.5",
+            "X-Desearch-Cost-Usd": "0.00025",
             "X-Desearch-Usage-Count": "7",
             "X-Desearch-Service": "twitter",
             "X-Desearch-Currency": "USD",
@@ -103,14 +103,14 @@ class ResponseMetadataTests(unittest.IsolatedAsyncioTestCase):
         self.assertIsInstance(result, DesearchResponse)
         self.assertIsInstance(result.data, list)
         self.assertIsInstance(result.data[0], TwitterScraperTweet)
-        self.assertEqual(result.metadata.cost_cents, 2.5)
+        self.assertEqual(result.metadata.cost_usd, 0.00025)
         self.assertEqual(result.metadata.usage_count, 7)
         self.assertEqual(result.metadata.service, "twitter")
         self.assertEqual(result.metadata.currency, "USD")
 
     async def test_custom_json_and_text_paths_support_include_metadata(self):
         headers = {
-            "X-Desearch-Cost-Cents": "0.5",
+            "X-Desearch-Cost-Usd": "0.00005",
             "X-Desearch-Usage-Count": "1",
             "X-Desearch-Service": "crawl",
             "X-Desearch-Currency": "USD",
@@ -121,7 +121,7 @@ class ResponseMetadataTests(unittest.IsolatedAsyncioTestCase):
         )
         self.assertIsInstance(urls_result, DesearchResponse)
         self.assertIsInstance(urls_result.data[0], TwitterScraperTweet)
-        self.assertEqual(urls_result.metadata.cost_cents, 0.5)
+        self.assertEqual(urls_result.metadata.cost_usd, 0.00005)
 
         crawl_client = self.make_client(FakeResponse(text_data="content", headers=headers))
         crawl_result = await crawl_client.web_crawl(
@@ -136,7 +136,7 @@ class ResponseMetadataTests(unittest.IsolatedAsyncioTestCase):
             FakeResponse(
                 json_data={"text": "ok"},
                 headers={
-                    "X-Desearch-Cost-Cents": "NaN",
+                    "X-Desearch-Cost-Usd": "NaN",
                     "X-Desearch-Usage-Count": "also-bad",
                 },
             )
@@ -148,7 +148,7 @@ class ResponseMetadataTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertIsInstance(result, DesearchResponse)
         self.assertEqual(result.data.text, "ok")
-        self.assertIsNone(result.metadata.cost_cents)
+        self.assertIsNone(result.metadata.cost_usd)
         self.assertIsNone(result.metadata.usage_count)
         self.assertIsNone(result.metadata.service)
         self.assertIsNone(result.metadata.currency)

--- a/tests/test_response_metadata.py
+++ b/tests/test_response_metadata.py
@@ -131,6 +131,21 @@ class ResponseMetadataTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(crawl_result.data, "content")
         self.assertEqual(crawl_result.metadata.service, "crawl")
 
+    async def test_legacy_cents_header_is_not_treated_as_canonical_usd_metadata(self):
+        client = self.make_client(
+            FakeResponse(
+                json_data={"text": "ok"},
+                headers={"X-Desearch-Cost-Cents": "0.15"},
+            )
+        )
+
+        result = await client.ai_search(
+            prompt="q", tools=["web"], include_metadata=True
+        )
+
+        self.assertIsInstance(result, DesearchResponse)
+        self.assertIsNone(result.metadata.cost_usd)
+
     async def test_missing_or_malformed_metadata_headers_do_not_break_successful_calls(self):
         client = self.make_client(
             FakeResponse(


### PR DESCRIPTION
## Problem
O-90’s Python SDK USD request-cost metadata contract was validated on the objective branch but not yet promoted to the main/release path. Giga approval was required before any main/package-facing release work.

## Root cause
The prior SDK package release surface still needed an approval-gated promotion step, and PyPI already has `desearch-py==1.2.0`, so a publishable release candidate needs a new package version.

## Fix
- Verified approval gate #1785 is `done`, `approved_by=giga`, `approved_at=2026-05-12T19:42:54.615+00:00` before release work.
- Promoted the objective-branch USD metadata contract toward `main` via this dispatcher-managed PR path.
- Kept scope to `Desearch-ai/desearch.py` only.
- USD metadata contract changes from the objective branch remain in:
  - `desearch_py/api.py`: parses `X-Desearch-Cost-Usd` into `cost_usd`.
  - `desearch_py/models.py`: exposes `cost_usd` on metadata/native response models.
  - `README.md` and `docs/architecture.md`: document the USD header/field.
  - `tests/test_response_metadata.py`: covers unchanged default returns and opt-in metadata wrapping.
- Added release prep in commit `24a06e4`:
  - `pyproject.toml` and `setup.py`: bump package version to `1.2.1`.
  - `README.md`, `docs/architecture.md`, `docs/features.md`: align documented package version to `1.2.1`.
  - `tests/test_response_metadata.py`: adds regression coverage that legacy `X-Desearch-Cost-Cents` is not treated as canonical USD metadata.
- Objective contract commit included in this branch: `a3b7e4e`.

## Validation
- Approval checked from Mission Control task #1785: explicit Giga approval recorded and task marked done.
- Drift check vs `origin/main`: only `Desearch-ai/desearch.py` SDK files/docs/tests/release metadata changed:
  - `README.md`
  - `desearch_py/api.py`
  - `desearch_py/models.py`
  - `docs/architecture.md`
  - `docs/features.md`
  - `pyproject.toml`
  - `setup.py`
  - `tests/test_response_metadata.py`
- Confirmed no canonical cents contract refs remain in README/docs/source with:
  - `grep -RInE "cost_cents|costCents|x-desearch-cost-cents|X-Desearch-Cost-Cents" README.md docs desearch_py --exclude-dir=_build --exclude-dir=.git`
- Tests:
  - `uv run python -m unittest tests/test_response_metadata.py` → 5 tests passed.
- Package build:
  - `uv run python setup.py sdist bdist_wheel` → built `dist/desearch_py-1.2.1-py3-none-any.whl` and `dist/desearch_py-1.2.1.tar.gz`.
  - `uv run twine check dist/*` → both artifacts passed.
- Noted build warnings only: existing setuptools warnings for direct `setup.py` usage and deprecated license classifier.

## Known gaps/blockers
- No PyPI upload, GitHub push, PR creation, tag, or merge was performed manually per task rules. Dispatcher should open the PR after this MC_DONE.
- Package publication remains gated on PR merge/release operator action for `desearch-py==1.2.1`; capture the final PR URL, merge SHA, tag, and PyPI version in the downstream release/validation step.

## Production expectation
After the dispatcher PR is merged and `desearch-py==1.2.1` is published, Python SDK users should keep unchanged default method returns. Users who opt in with `include_metadata=True` should receive native USD metadata via `response.metadata.cost_usd`, parsed from `X-Desearch-Cost-Usd`, with legacy cents naming absent from canonical SDK docs/examples.

---
Task: #1788 — Promote and release O-90 USD metadata in desearch.py
Opened automatically by mission-control dispatcher.