### PR TITLE
feat: add domain filters to ai_search, default date_filter to None

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,17 +57,21 @@ AI-powered multi-source contextual search. Searches across web, X (Twitter), Red
 | `tools`                  | `List[str]`     | Yes      | —                          | List of tools to search with (e.g. `web`, `twitter`, `reddit`, `hackernews`, `youtube`, `wikipedia`, `arxiv`) |
 | `start_date`             | `Optional[str]` | No       | `None`                     | Start date in UTC (YYYY-MM-DDTHH:MM:SSZ)                                                                      |
 | `end_date`               | `Optional[str]` | No       | `None`                     | End date in UTC (YYYY-MM-DDTHH:MM:SSZ)                                                                        |
-| `date_filter`            | `Optional[str]` | No       | `PAST_24_HOURS`            | Predefined date filter for search results                                                                     |
+| `date_filter`            | `Optional[str]` | No       | `None`                     | Deprecated relative window; the API translates it to `start_date`/`end_date`                                  |
 | `result_type`            | `Optional[str]` | No       | `LINKS_WITH_FINAL_SUMMARY` | Result type (`ONLY_LINKS` or `LINKS_WITH_FINAL_SUMMARY`)                                                      |
 | `system_message`         | `Optional[str]` | No       | `None`                     | System message for the search                                                                                 |
 | `scoring_system_message` | `Optional[str]` | No       | `None`                     | System message for scoring the response                                                                       |
+| `include_domains`        | `Optional[List[str]]` | No  | `None`                     | Restrict Web Search results to these domains                                                                  |
+| `exclude_domains`        | `Optional[List[str]]` | No  | `None`                     | Drop Web Search results from these domains                                                                    |
 | `count`                  | `Optional[int]` | No       | `None`                     | Number of results per source (10–200)                                                                         |
 
 ```python
 result = await desearch.ai_search(
     prompt="Bittensor",
-    tools=["web", "hackernews", "reddit", "wikipedia", "youtube", "twitter", "arxiv"],
-    date_filter="PAST_24_HOURS",
+    tools=["web"],
+    start_date="2025-05-01T00:00:00Z",
+    end_date="2025-05-08T00:00:00Z",
+    include_domains=["bbc.com", "reuters.com"],
     result_type="LINKS_WITH_FINAL_SUMMARY",
     count=20,
 )

--- a/desearch_py/api.py
+++ b/desearch_py/api.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Any, AsyncIterator, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
 import aiohttp
 
@@ -82,7 +82,9 @@ class Desearch:
                 response.raise_for_status()
                 return await response.json()
         except aiohttp.ClientResponseError as e:
-            logger.error("HTTP error %s for %s %s: %s", e.status, method, url, e.message)
+            logger.error(
+                "HTTP error %s for %s %s: %s", e.status, method, url, e.message
+            )
             raise
         except aiohttp.ClientError as e:
             logger.error("Client error for %s %s: %s", method, url, str(e))
@@ -94,10 +96,12 @@ class Desearch:
         tools: List[str],
         start_date: Optional[str] = None,
         end_date: Optional[str] = None,
-        date_filter: Optional[str] = "PAST_24_HOURS",
+        date_filter: Optional[str] = None,
         result_type: Optional[str] = "LINKS_WITH_FINAL_SUMMARY",
         system_message: Optional[str] = None,
         scoring_system_message: Optional[str] = None,
+        include_domains: Optional[List[str]] = None,
+        exclude_domains: Optional[List[str]] = None,
         count: Optional[int] = None,
     ) -> Union[ResponseData, Dict[str, Any]]:
         """
@@ -108,10 +112,12 @@ class Desearch:
             tools (List[str]): List of tools to search with (e.g. web, twitter, reddit).
             start_date (Optional[str]): Start date in UTC (YYYY-MM-DDTHH:MM:SSZ).
             end_date (Optional[str]): End date in UTC (YYYY-MM-DDTHH:MM:SSZ).
-            date_filter (Optional[str]): Predefined date filter for search results.
+            date_filter (Optional[str]): Deprecated relative window; the API translates it to start_date/end_date. Prefer start_date/end_date.
             result_type (Optional[str]): Result type (ONLY_LINKS or LINKS_WITH_FINAL_SUMMARY).
             system_message (Optional[str]): System message for the search.
             scoring_system_message (Optional[str]): System message for scoring the response.
+            include_domains (Optional[List[str]]): Restrict Web Search results to these domains.
+            exclude_domains (Optional[List[str]]): Drop Web Search results from these domains.
             count (Optional[int]): Number of results to return per source (10-200).
 
         Returns:
@@ -130,6 +136,8 @@ class Desearch:
                 "result_type": result_type,
                 "system_message": system_message,
                 "scoring_system_message": scoring_system_message,
+                "include_domains": include_domains,
+                "exclude_domains": exclude_domains,
                 "count": count,
             }.items()
             if v is not None
@@ -547,12 +555,17 @@ class Desearch:
         client = await self._ensure_session()
         try:
             async with client.request(
-                "GET", request_url, params=params, timeout=aiohttp.ClientTimeout(total=120)
+                "GET",
+                request_url,
+                params=params,
+                timeout=aiohttp.ClientTimeout(total=120),
             ) as response:
                 response.raise_for_status()
                 return await response.text()
         except aiohttp.ClientResponseError as e:
-            logger.error("HTTP error %s for GET %s: %s", e.status, request_url, e.message)
+            logger.error(
+                "HTTP error %s for GET %s: %s", e.status, request_url, e.message
+            )
             raise
         except aiohttp.ClientError as e:
             logger.error("Client error for GET %s: %s", request_url, str(e))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ authors = ["Desearch AI <hello@desearch.ai>"]
 description = "Python SDK for Desearch API."
 name = "desearch-py"
 readme = "README.md"
-version = "1.2.0"
+version = "1.3.0"
 
 [tool.poetry.dependencies]
 aiohttp = ">=3.8"

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="desearch_py",
-    version="1.2.0",
+    version="1.3.0",
     description="A Python SDK for interacting with the Desearch API service.",
     author="Desearch",
     author_email="",


### PR DESCRIPTION
Brings `ai_search` in line with the updated public-api surface.

## Changes
- Add `include_domains` / `exclude_domains` params to `ai_search` (restrict / drop Web Search results by domain); forwarded in the request body.
- Default `date_filter` to `None` instead of `"PAST_24_HOURS"` — no implicit date window. The enum is deprecated; the API now translates any supplied `date_filter` into `start_date`/`end_date`, so prefer those.
- README params table + example updated (start/end dates + domain filters).

`start_date`, `end_date`, `result_type` were already supported. ruff clean.
